### PR TITLE
Chore: Enhance alarm reliability and add permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,11 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".CheermateApp"
@@ -18,7 +21,8 @@
         android:label="@string/app_name"
         android:roundIcon="@drawable/ic_cheermate_logo"
         android:supportsRtl="true"
-        android:theme="@style/Theme.CheermateApp">
+        android:theme="@style/Theme.CheermateApp"
+        android:attributionTags="@null">
 
         <!-- ActivityLogin as launcher (working fix) -->
         <activity
@@ -73,7 +77,9 @@
             android:showWhenLocked="true"
             android:turnScreenOn="true"
             android:excludeFromRecents="true"
-            android:launchMode="singleInstance" />
+            android:launchMode="singleInstance"
+            android:showOnLockScreen="true"
+            android:screenOrientation="portrait" />
 
         <!-- Broadcast Receivers -->
 

--- a/app/src/main/java/com/cheermateapp/util/NotificationUtil.kt
+++ b/app/src/main/java/com/cheermateapp/util/NotificationUtil.kt
@@ -22,27 +22,41 @@ object NotificationUtil {
     private const val CHANNEL_NAME = "Task Reminders"
     private const val CHANNEL_DESCRIPTION = "Notifications for task reminders"
     
+    // Additional channels for different notification types
+    private const val UPCOMING_ALARMS_CHANNEL_ID = "upcoming_alarms"
+    private const val UPCOMING_ALARMS_CHANNEL_NAME = "Upcoming Alarms"
+    private const val UPCOMING_ALARMS_CHANNEL_DESCRIPTION = "Notifications shown before alarms trigger"
+    
     /**
-     * Create notification channel (required for Android O and above)
+     * Create all notification channels (required for Android O and above)
      */
     fun createNotificationChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val importance = NotificationManager.IMPORTANCE_HIGH
-            val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, importance).apply {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            
+            // Create task reminders channel (high priority with alarm sound)
+            val taskRemindersChannel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH).apply {
                 description = CHANNEL_DESCRIPTION
                 enableLights(true)
                 enableVibration(true)
-                // Set the default alarm sound for the channel
                 setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM), null)
-                // Set a custom vibration pattern for the channel
-                // Example: wait 0ms, vibrate 1000ms, pause 500ms, vibrate 1000ms
                 vibrationPattern = longArrayOf(0, 1000, 500, 1000)
+                setBypassDnd(true) // Allow to bypass Do Not Disturb
             }
             
-            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
+            // Create upcoming alarms channel (medium priority, no sound)
+            val upcomingAlarmsChannel = NotificationChannel(UPCOMING_ALARMS_CHANNEL_ID, UPCOMING_ALARMS_CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT).apply {
+                description = UPCOMING_ALARMS_CHANNEL_DESCRIPTION
+                enableLights(true)
+                enableVibration(false) // No vibration for upcoming alarms
+                setSound(null, null) // No sound for upcoming alarms
+            }
             
-            android.util.Log.d("NotificationUtil", "✅ Notification channel created")
+            // Register both channels
+            notificationManager.createNotificationChannel(taskRemindersChannel)
+            notificationManager.createNotificationChannel(upcomingAlarmsChannel)
+            
+            android.util.Log.d("NotificationUtil", "✅ All notification channels created")
         }
     }
     


### PR DESCRIPTION
This commit improves the reliability of full-screen alarm notifications and adds the necessary permissions.

Specifically:
- Adds `USE_FULL_SCREEN_INTENT`, `SYSTEM_ALERT_WINDOW`, and `WAKE_LOCK` permissions in `AndroidManifest.xml` to ensure alarms can be displayed reliably, especially on locked screens.
- Refactors `AlarmReceiver` to prioritize using a `fullScreenIntent` for launching the `AlarmActivity`, which is the more modern and reliable method for displaying alarms from the background.
- Adjusts the `AlarmActivity` launch intent flags and adds error handling for background activity start attempts.
- Defines a new notification channel ("Upcoming Alarms") for non-intrusive, pre-alarm notifications.
- Updates the main "Task Reminders" notification channel to bypass Do Not Disturb mode.